### PR TITLE
Fix description of simulator ports

### DIFF
--- a/en/simulation/README.md
+++ b/en/simulation/README.md
@@ -76,11 +76,11 @@ These ports are:
   Multi-vehicle simulations use a separate remote port for each instance, allocated sequentially from `14540` to `14549`
   (additional instances all use port `14549`).
   :::
-* The simulator's local TCP Port **4560** is used for communication with PX4.
-  PX4 listens to this port, and simulators are expected to initiate the communication by broadcasting data to this port.
+* The simulator's local TCP Port, **4560**, is used for communication with PX4.
+  The simulator listens to this port, and PX4 initiates a TCP connection to it.
 
 :::note
-The ports for the GCS and offboard APIs are set in configuration files, while the simulator broadcast port is hard-coded in the simulation MAVLink module.
+The ports for the GCS, offboard APIs and simulator are specified by startup scripts. See [System Startup](../concept/system_startup.md) to learn more.
 :::
 
 


### PR DESCRIPTION
This document didn't accurately describe how PX4 and the simulator communicate. This change fixes the description.

I checked the source code for gazebo and jmavsim. Both simulators listen and PX4 initiates a TCP connection.

In gazebo, this is where a TCP socket is created:
https://github.com/PX4/PX4-SITL_gazebo/blob/7fda4d311a9daff4bec4f2fe83e63fde0b8f04b0/src/mavlink_interface.cpp#L102
This is where that socket is bound to the port: 
https://github.com/PX4/PX4-SITL_gazebo/blob/7fda4d311a9daff4bec4f2fe83e63fde0b8f04b0/src/mavlink_interface.cpp#L148
And this is where it listens for a connection from PX4:
https://github.com/PX4/PX4-SITL_gazebo/blob/7fda4d311a9daff4bec4f2fe83e63fde0b8f04b0/src/mavlink_interface.cpp#L154

Similar code exists in jmavsim. The bulk of TCP server code is in this method:
https://github.com/PX4/jMAVSim/blob/0a5375a70689aac53143768de9033034f3636022/src/me/drton/jmavsim/TCPMavLinkPort.java#L58-L64